### PR TITLE
Additional image verification

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -29,6 +29,16 @@ class SiteGenerator:
 
     def process_photo(self, external_path, photo, output_dir):
         new_original_photo = os.path.join(output_dir, "original_%s" % os.path.basename(photo))
+        
+        # Verify original first to avoid PIL errors later when generating thumbnails etc
+        try:
+            with Image.open(photo) as im:
+                im.verify()
+            # Unfortunately verify only catches a few defective images, this transpose catches more. Verify requires subsequent reopen according to Pillow docs.
+            with Image.open(photo) as im2:
+                im2.transpose(Image.FLIP_TOP_BOTTOM)
+        except Exception as e:
+            raise PhotoProcessingFailure(message="Image Verification: " + str(e))
 
         # Only copy if overwrite explicitly asked for or if doesn't exist
         if self.overwrite or not os.path.exists(new_original_photo):


### PR DESCRIPTION
Empty PNG images, various defects in JPG images and so on require pre-verification, else Fussel throws errors later and stops generating its gallery.

It might be better to not use the second transpose hack that is only to get pillow to validate the image better, however verify alone did not do the job and I preferred this more complete pre-verification to catching errors later. Maybe I just don't know Pillow well enough and there is another way. Or maybe all the steps themselves could catch errors and revert/delete the so far generated data as appropriate.