### PR TITLE
Fix photo name showing as `undefined` (#81)

### DIFF
--- a/web/src/component/Album.js
+++ b/web/src/component/Album.js
@@ -93,7 +93,7 @@ export default class Album extends Component {
                 views={this.props.album["photos"].map(x => ({
                   ...x,
                   srcset: x.srcSet,
-                  caption: x.title
+                  caption: x.name
                 }))}
               />
             </Modal>


### PR DESCRIPTION
The property `title` does not exist and therefore the name shows as `undefined`.